### PR TITLE
change serve:ssr definition

### DIFF
--- a/js-storefront/spartacusstore/package.json
+++ b/js-storefront/spartacusstore/package.json
@@ -9,7 +9,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "dev:ssr": "ng run spartacusstore:serve-ssr",
-    "serve:ssr": "node dist/spartacusstore/server/main.js",
+    "serve:ssr": "node dist/main.js",
     "build:ssr": "ng build --prod && ng run spartacusstore:server:production && mv dist/spartacusstore-server/main.js dist/server.js || move dist\\spartacusstore-server\\main.js dist\\server.js",
     "prerender": "ng run spartacusstore:prerender"
   },


### PR DESCRIPTION
Hi Team, 

In [package.json](https://github.com/SAP-samples/cloud-commerce-sample-setup/blob/2011-spartacus/js-storefront/spartacusstore/package.json) of SAP-samples / cloud-commerce-sample-setup  (which is official)

The config for command `serve:ssr` is wrong.

Current value is:
`"node dist/spartacusstore/server/main.js"`  

this is **Workaround for the _New_ Manifest Format** according to <<[Workaround for Issue with Server-Side Rendering in Spartacus 2.0 or later and SAP Commerce Cloud for Public Cloud](https://sap.github.io/spartacus-docs/ssr-ccv2-issue-spartacus-version-2/)>>

While we should use **Workaround for the _Old_ Manifest Format**,
as the other 3 places are all set with **Workaround for the _Old_ Manifest Format**, except this.

Right value is:
`"node dist/main.js"`
this is **Workaround for the _Old_ Manifest Format**

Please correct it.

Thanks!

Regards,

Timothy